### PR TITLE
Refactor: replace loading components with a unified Loader component

### DIFF
--- a/src/app/(frontend)/[lang]/99Stud/loading.tsx
+++ b/src/app/(frontend)/[lang]/99Stud/loading.tsx
@@ -1,17 +1,9 @@
 import { FC } from "react";
 
-import { cn } from "@/lib/utils";
+import Loader from "@/components/Common/Loader";
 
 const Loading: FC = async () => {
-  return (
-    <div
-      className={cn("hidden h-full w-full items-center justify-center lg:flex")}
-    >
-      <span className="animate-text-gradient via-metal inline-flex bg-linear-to-r from-stone-400 to-stone-400 bg-[200%_auto] bg-clip-text text-center text-3xl font-bold text-transparent md:pl-72">
-        Loading page...
-      </span>
-    </div>
-  );
+  return <Loader isInnerMenuOpen={false} label="Loading 99Stud..." />;
 };
 
 export default Loading;

--- a/src/app/(frontend)/[lang]/blog/[slug]/loading.tsx
+++ b/src/app/(frontend)/[lang]/blog/[slug]/loading.tsx
@@ -1,17 +1,9 @@
 import { FC } from "react";
 
-import { cn } from "@/lib/utils";
+import Loader from "@/components/Common/Loader";
 
 const Loading: FC = async () => {
-  return (
-    <div
-      className={cn("hidden h-full w-full items-center justify-center lg:flex")}
-    >
-      <span className="inline-flex animate-text-gradient bg-linear-to-r from-stone-400 via-metal to-stone-400 bg-[200%_auto] bg-clip-text text-center  text-3xl font-bold text-transparent md:pl-72">
-        Loading blog post...
-      </span>
-    </div>
-  );
+  return <Loader isInnerMenuOpen={true} label="Loading blog post..." />;
 };
 
 export default Loading;

--- a/src/app/(frontend)/[lang]/blog/loading.tsx
+++ b/src/app/(frontend)/[lang]/blog/loading.tsx
@@ -3,7 +3,7 @@ import { FC } from "react";
 import Loader from "@/components/Common/Loader";
 
 const Loading: FC = async () => {
-  return <Loader isInnerMenuOpen={true} label="Loading experience..." />;
+  return <Loader isInnerMenuOpen={false} label="Loading blog..." />;
 };
 
 export default Loading;

--- a/src/app/(frontend)/[lang]/experiences/loading.tsx
+++ b/src/app/(frontend)/[lang]/experiences/loading.tsx
@@ -3,7 +3,7 @@ import { FC } from "react";
 import Loader from "@/components/Common/Loader";
 
 const Loading: FC = async () => {
-  return <Loader isInnerMenuOpen={true} label="Loading experience..." />;
+  return <Loader isInnerMenuOpen={false} label="Loading experiences..." />;
 };
 
 export default Loading;

--- a/src/app/(frontend)/[lang]/legal/notice/loading.tsx
+++ b/src/app/(frontend)/[lang]/legal/notice/loading.tsx
@@ -3,7 +3,7 @@ import { FC } from "react";
 import Loader from "@/components/Common/Loader";
 
 const Loading: FC = async () => {
-  return <Loader isInnerMenuOpen={true} label="Loading experience..." />;
+  return <Loader isInnerMenuOpen={false} label="Loading legal notice..." />;
 };
 
 export default Loading;

--- a/src/app/(frontend)/[lang]/loading.tsx
+++ b/src/app/(frontend)/[lang]/loading.tsx
@@ -1,21 +1,9 @@
 import { FC } from "react";
 
-import { cn } from "@/lib/utils";
+import Loader from "@/components/Common/Loader";
 
 const Loading: FC = async () => {
-  return (
-    <div
-      className={cn("hidden h-full w-full items-center justify-center lg:flex")}
-    >
-      <span
-        className={cn(
-          "animate-text-gradient via-metal inline-flex bg-linear-to-r from-stone-400 to-stone-400 bg-[200%_auto] bg-clip-text text-center text-3xl font-bold text-transparent",
-        )}
-      >
-        Loading home...
-      </span>
-    </div>
-  );
+  return <Loader isInnerMenuOpen={false} label="Loading home..." />;
 };
 
 export default Loading;

--- a/src/app/(frontend)/[lang]/open-source/loading.tsx
+++ b/src/app/(frontend)/[lang]/open-source/loading.tsx
@@ -3,7 +3,7 @@ import { FC } from "react";
 import Loader from "@/components/Common/Loader";
 
 const Loading: FC = async () => {
-  return <Loader isInnerMenuOpen={true} label="Loading experience..." />;
+  return <Loader isInnerMenuOpen={false} label="Loading open source..." />;
 };
 
 export default Loading;

--- a/src/components/Common/Loader.tsx
+++ b/src/components/Common/Loader.tsx
@@ -1,0 +1,24 @@
+import { FC } from "react";
+
+import { cn } from "@/lib/utils";
+
+type Props = {
+  label: string;
+  isInnerMenuOpen: boolean;
+};
+
+const Loader: FC<Props> = ({ label, isInnerMenuOpen }) => {
+  return (
+    <div className={cn("flex h-screen w-full items-center justify-center")}>
+      <span
+        className={`animate-text-gradient via-metal inline-flex bg-linear-to-r from-stone-400 to-stone-400 bg-[200%_auto] bg-clip-text text-center text-3xl font-bold text-transparent ${
+          isInnerMenuOpen ? "md:pl-72" : ""
+        }`}
+      >
+        {label}
+      </span>
+    </div>
+  );
+};
+
+export default Loader;


### PR DESCRIPTION
- Updated loading components across various pages to use a new Loader component for consistency.
- Removed old loading UI code and replaced it with the Loader component, which accepts a label and a prop to manage inner menu state.
- Added new loading components for blog, experiences, legal notice, and open source sections.